### PR TITLE
#541 to add another avatar on task page

### DIFF
--- a/frontend/src/components/task/task.js
+++ b/frontend/src/components/task/task.js
@@ -727,20 +727,20 @@ class Task extends Component {
               } }
             >
               { task.data.metadata ? (
-                <div style={ { position: 'absolute', left: 18, top: 5 } }>
+                <div style={ { position: 'absolute', left: 38, top: 5 } }>
                   <Typography color='default'>
                     <FormattedMessage id='task.status.author.label' defaultMessage='Author' />
                   </Typography>
                 </div>
               ) : (
-                <div style={ { position: 'absolute', left: 18, top: 5 } }>
+                <div style={ { position: 'absolute', left: 38, top: 5 } }>
                   <Typography color='default'>
                     <FormattedMessage id='task.status.author.missing' defaultMessage='author info unknown' />
                   </Typography>
                 </div>
               ) }
               { task.data.metadata &&
-              <FormattedMessage id='task.status.created.name' defaultMessage='Created by {name}' values={ {
+              <FormattedMessage id='task.status.author.name' defaultMessage='Author from provider {name}' values={ {
                 name: task.data.metadata.issue.user.login
               } }>
                 { (msg) => (
@@ -755,6 +755,29 @@ class Task extends Component {
                     >
                       <Avatar
                         src={ task.data.metadata.issue.user.avatar_url }
+                        className={ classNames(classes.avatar) }
+                      />
+                    </a>
+                  </Tooltip>
+                ) }
+              </FormattedMessage>
+              }
+              { task.data.metadata &&
+              <FormattedMessage id='task.status.author.name' defaultMessage='Author from provider {name}' values={ {
+                name: this.props.user.name
+              } }>
+                { (msg) => (
+                  <Tooltip
+                    id='tooltip-github'
+                    title={ msg }
+                    placement='bottom'
+                  >
+                    <a
+                      href={`${this.props.user.html_url}` }
+                      target='_blank'
+                    >
+                      <Avatar
+                        src={ this.props.user.avatar_url }
                         className={ classNames(classes.avatar) }
                       />
                     </a>


### PR DESCRIPTION
Task page to display 2 avatars one the author from provider and the other one the importer at Gitpay

## Description

> Description of the pull request

## Changes

- Where your changes apply

## Issue
![image](https://user-images.githubusercontent.com/63766141/79687737-037d3100-8267-11ea-8338-bbf8e103f441.png)

> Closes #000

## Impacted Area

> Main page

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Create / log user
- Create Task
- Other steps

## Before
> Screenshot from the state before

## After
> Screenshot from the state after your Pull Request
![image](https://user-images.githubusercontent.com/63766141/79687747-15f76a80-8267-11ea-9ad4-e31ff1b231f2.png)
![image](https://user-images.githubusercontent.com/63766141/79687750-1f80d280-8267-11ea-96f1-25e102cb1619.png)

